### PR TITLE
Fix XE-99S SIEPON-A Web save reliability

### DIFF
--- a/mod/siepon_a/SOURCE/script/web/www/ForceBridge.html
+++ b/mod/siepon_a/SOURCE/script/web/www/ForceBridge.html
@@ -35,7 +35,7 @@
     })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/ForceTraffic.html
+++ b/mod/siepon_a/SOURCE/script/web/www/ForceTraffic.html
@@ -26,6 +26,7 @@
     })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>

--- a/mod/siepon_a/SOURCE/script/web/www/MacSet.html
+++ b/mod/siepon_a/SOURCE/script/web/www/MacSet.html
@@ -19,6 +19,7 @@ Exanple : AA:BB:CC:11:22:33</p>
       document.getElementById("MacAddr").value = data.MacAddr;
     });
   </script>
+<script src="save.js"></script>
 
 </body>
 </html>

--- a/mod/siepon_a/SOURCE/script/web/www/RebootBlock.html
+++ b/mod/siepon_a/SOURCE/script/web/www/RebootBlock.html
@@ -26,6 +26,7 @@
     })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>

--- a/mod/siepon_a/SOURCE/script/web/www/TLV_D703.html
+++ b/mod/siepon_a/SOURCE/script/web/www/TLV_D703.html
@@ -33,7 +33,7 @@ fetch("cgi-bin/set_TLV_D703_get.sh")
   })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/TLV_D704.html
+++ b/mod/siepon_a/SOURCE/script/web/www/TLV_D704.html
@@ -44,7 +44,7 @@ fetch("cgi-bin/set_TLV_D704_get.sh")
   })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/TLV_D705.html
+++ b/mod/siepon_a/SOURCE/script/web/www/TLV_D705.html
@@ -26,7 +26,7 @@ fetch("cgi-bin/set_TLV_D705_get.sh")
   })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/TLV_D706.html
+++ b/mod/siepon_a/SOURCE/script/web/www/TLV_D706.html
@@ -21,7 +21,7 @@ fetch("cgi-bin/set_TLV_D706_get.sh")
   })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/TLV_D711.html
+++ b/mod/siepon_a/SOURCE/script/web/www/TLV_D711.html
@@ -21,7 +21,7 @@ fetch("cgi-bin/set_TLV_D711_get.sh")
   })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/TLV_D712.html
+++ b/mod/siepon_a/SOURCE/script/web/www/TLV_D712.html
@@ -21,7 +21,7 @@ fetch("cgi-bin/set_TLV_D712_get.sh")
   })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/TLV_D713.html
+++ b/mod/siepon_a/SOURCE/script/web/www/TLV_D713.html
@@ -21,7 +21,7 @@ fetch("cgi-bin/set_TLV_D713_get.sh")
   })
   .catch(err => console.error(err));
 </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_ForceBridge_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_ForceBridge_set.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 # POST data get
 read POSTDATA
@@ -18,22 +30,23 @@ VALUE=$(urldecode "$(get_param ForceBridge)")
 MACADDR=$(urldecode "$(get_param MacAddr)")
 
 # MAC check
-echo "$MACADDR" | grep -Eq '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$'
-if [ $? -ne 0 ]; then
-    echo "Invalid MAC address"
-    exit 1
-fi
+echo "$MACADDR" | grep -Eq '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' ||
+    fail_request "400 Bad Request" "Invalid MAC address"
 
 if [ "$VALUE" = "Enable" ]; then
-    fw_setenv CA8271_FORCE_BRIDGE 1
+    BRIDGE=1
 elif [ "$VALUE" = "Disable" ]; then
-    fw_setenv CA8271_FORCE_BRIDGE 0
+    BRIDGE=0
 else
-    echo "Invalid value"
-    exit 1
+    fail_request "400 Bad Request" "Invalid value"
 fi
 
-fw_setenv CA8271_FORCE_BRIDGE_MAC $MACADDR
+if ! fw_setenv -s - <<EOF
+CA8271_FORCE_BRIDGE $BRIDGE
+CA8271_FORCE_BRIDGE_MAC $MACADDR
+EOF
+then
+    fail_request "500 Internal Server Error" "Save failed."
+fi
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_ForceTraffic_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_ForceTraffic_set.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 # POST data get
 read POSTDATA
@@ -10,14 +22,14 @@ read POSTDATA
 VALUE=$(echo "$POSTDATA" | sed -n 's/^ForceTraffic=\(.*\)$/\1/p')
 
 if [ "$VALUE" = "Enable" ]; then
-    fw_setenv CA8271_FORCE_TRAFFIC 1
+    TRAFFIC=1
 elif [ "$VALUE" = "Disable" ]; then
-    fw_setenv CA8271_FORCE_TRAFFIC 0
+    TRAFFIC=0
 else
-    echo "Invalid value"
-    exit 1
+    fail_request "400 Bad Request" "Invalid value"
 fi
 
-echo "Saved"
+fw_setenv CA8271_FORCE_TRAFFIC "$TRAFFIC" ||
+    fail_request "500 Internal Server Error" "Save failed."
 
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_RebootBlock_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_RebootBlock_set.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 # POST data get
 read POSTDATA
@@ -10,14 +22,14 @@ read POSTDATA
 VALUE=$(echo "$POSTDATA" | sed -n 's/^RebootBlock=\(.*\)$/\1/p')
 
 if [ "$VALUE" = "Enable" ]; then
-    fw_setenv CA8271_REBOOT_BLOCK 1
+    REBOOT_BLOCK=1
 elif [ "$VALUE" = "Disable" ]; then
-    fw_setenv CA8271_REBOOT_BLOCK 0
+    REBOOT_BLOCK=0
 else
-    echo "Invalid value"
-    exit 1
+    fail_request "400 Bad Request" "Invalid value"
 fi
 
-echo "Saved"
+fw_setenv CA8271_REBOOT_BLOCK "$REBOOT_BLOCK" ||
+    fail_request "500 Internal Server Error" "Save failed."
 
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D703_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D703_set.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POSTDATA
 
@@ -18,20 +30,28 @@ BootCRC=$(urldecode "$(get_param BootCRC)")
 FirmVer=$(urldecode "$(get_param FirmVer)")
 FirmCRC=$(urldecode "$(get_param FirmCRC)")
 
-echo "$BootVer" | grep -Eq '^[0-9A-Fa-f]{4}$' || { echo "Invalid BootVer"; exit 1; }
-echo "$BootCRC" | grep -Eq '^[0-9A-Fa-f]{8}$' || { echo "Invalid BootCRC"; exit 1; }
-echo "$FirmVer" | grep -Eq '^[0-9A-Fa-f]{4}$' || { echo "Invalid FirmVer"; exit 1; }
-echo "$FirmCRC" | grep -Eq '^[0-9A-Fa-f]{8}$' || { echo "Invalid FirmCRC"; exit 1; }
+echo "$BootVer" | grep -Eq '^[0-9A-Fa-f]{4}$' ||
+    fail_request "400 Bad Request" "Invalid BootVer"
+echo "$BootCRC" | grep -Eq '^[0-9A-Fa-f]{8}$' ||
+    fail_request "400 Bad Request" "Invalid BootCRC"
+echo "$FirmVer" | grep -Eq '^[0-9A-Fa-f]{4}$' ||
+    fail_request "400 Bad Request" "Invalid FirmVer"
+echo "$FirmCRC" | grep -Eq '^[0-9A-Fa-f]{8}$' ||
+    fail_request "400 Bad Request" "Invalid FirmCRC"
 
 BootVer=$(echo "$BootVer" | tr 'a-f' 'A-F')
 BootCRC=$(echo "$BootCRC" | tr 'a-f' 'A-F')
 FirmVer=$(echo "$FirmVer" | tr 'a-f' 'A-F')
 FirmCRC=$(echo "$FirmCRC" | tr 'a-f' 'A-F')
 
-fw_setenv CA8271_FW_BOOTVER "$BootVer"
-fw_setenv CA8271_FW_BOOTCRC "$BootCRC"
-fw_setenv CA8271_FW_FWVER "$FirmVer"
-fw_setenv CA8271_FW_FWCRC "$FirmCRC"
+if ! fw_setenv -s - <<EOF
+CA8271_FW_BOOTVER $BootVer
+CA8271_FW_BOOTCRC $BootCRC
+CA8271_FW_FWVER $FirmVer
+CA8271_FW_FWCRC $FirmCRC
+EOF
+then
+    fail_request "500 Internal Server Error" "Save failed."
+fi
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D704_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D704_set.sh
@@ -2,8 +2,20 @@
 
 CONFIG="/config/scfg.txt"
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POSTDATA
 
@@ -19,24 +31,33 @@ JDECID=$(urldecode "$(get_param JDECID)")
 Model=$(urldecode "$(get_param Model)")
 Version=$(urldecode "$(get_param Version)")
 
-echo "$JDECID" | grep -Eq '^[0-9A-Fa-f]{4}$' || { echo "Invalid JDECID"; exit 1; }
-echo "$Model" | grep -Eq '^[0-9A-Fa-f]{4}$' || { echo "Invalid Model"; exit 1; }
-echo "$Version" | grep -Eq '^[0-9A-Fa-f]{8}$' || { echo "Invalid Version"; exit 1; }
+echo "$JDECID" | grep -Eq '^[0-9A-Fa-f]{4}$' ||
+    fail_request "400 Bad Request" "Invalid JDECID"
+echo "$Model" | grep -Eq '^[0-9A-Fa-f]{4}$' ||
+    fail_request "400 Bad Request" "Invalid Model"
+echo "$Version" | grep -Eq '^[0-9A-Fa-f]{8}$' ||
+    fail_request "400 Bad Request" "Invalid Version"
 
 JDECID=$(echo "$JDECID" | tr 'a-f' 'A-F')
 Model=$(echo "$Model" | tr 'a-f' 'A-F')
 Version=$(echo "$Version" | tr 'a-f' 'A-F')
 
-fw_setenv CA8271_CHIP_ID "$JDECID"
-fw_setenv CA8271_CHIP_MODEL "$Model"
+if ! fw_setenv -s - <<EOF
+CA8271_CHIP_ID $JDECID
+CA8271_CHIP_MODEL $Model
+EOF
+then
+    fail_request "500 Internal Server Error" "Save failed."
+fi
 
 hex_array=$(echo "$Version" | sed 's/../0x&, /g' | sed 's/, $//')
 formatted="{${hex_array}}"
 if grep -q '^CHAR-ARRAY CFG_ID_HW_VERSION' "$CONFIG"; then
-    sed -i "s/^CHAR-ARRAY CFG_ID_HW_VERSION.*/CHAR-ARRAY CFG_ID_HW_VERSION = ${formatted};/" "$CONFIG"
+    sed -i "s/^CHAR-ARRAY CFG_ID_HW_VERSION.*/CHAR-ARRAY CFG_ID_HW_VERSION = ${formatted};/" "$CONFIG" ||
+        fail_request "500 Internal Server Error" "Save failed."
 else
-    echo "CHAR-ARRAY CFG_ID_HW_VERSION = ${formatted};" >> "$CONFIG"
+    echo "CHAR-ARRAY CFG_ID_HW_VERSION = ${formatted};" >> "$CONFIG" ||
+        fail_request "500 Internal Server Error" "Save failed."
 fi
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D705_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D705_set.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POSTDATA
 
@@ -16,14 +28,20 @@ get_param() {
 year=$(urldecode "$(get_param year)")
 Date=$(urldecode "$(get_param Date)")
 
-echo "$year" | grep -Eq '^[0-9A-Fa-f]{4}$' || { echo "Invalid year"; exit 1; }
-echo "$Date" | grep -Eq '^[0-9A-Fa-f]{2}$' || { echo "Invalid Date"; exit 1; }
+echo "$year" | grep -Eq '^[0-9A-Fa-f]{4}$' ||
+    fail_request "400 Bad Request" "Invalid year"
+echo "$Date" | grep -Eq '^[0-9A-Fa-f]{2}$' ||
+    fail_request "400 Bad Request" "Invalid Date"
 
 year=$(echo "$year" | tr 'a-f' 'A-F')
 Date=$(echo "$Date" | tr 'a-f' 'A-F')
 
-fw_setenv CA8271_MANU_YEAR "$year"
-fw_setenv CA8271_MANU_MON "$Date"
+if ! fw_setenv -s - <<EOF
+CA8271_MANU_YEAR $year
+CA8271_MANU_MON $Date
+EOF
+then
+    fail_request "500 Internal Server Error" "Save failed."
+fi
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D706_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D706_set.sh
@@ -2,27 +2,48 @@
 
 CONFIG="/etc/onu_manu_modle.ini"
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POSTDATA
 
 urldecode() {
-  echo "$1" | sed 's/+/ /g; s/%3[Aa]/:/g; s/%2[Ff]/\//g'
+    printf '%b' "$(printf '%s' "$1" | sed 's/+/ /g; s/%/\\x/g')"
 }
 
 get_param() {
-  echo "$POSTDATA" | tr '&' '\n' | grep "^$1=" | cut -d= -f2
+    echo "$POSTDATA" | tr '&' '\n' | grep "^$1=" | cut -d= -f2-
 }
 
 info=$(urldecode "$(get_param info)")
 
+[ "${#info}" -le 64 ] ||
+    fail_request "400 Bad Request" "Invalid Manufacture Info"
+printf '%s' "$info" | LC_ALL=C grep -Eq '^[[:print:]]*$' ||
+    fail_request "400 Bad Request" "Invalid Manufacture Info"
+case "$info" in
+    *\"*) fail_request "400 Bad Request" "Invalid Manufacture Info" ;;
+esac
 
+escaped=$(printf '%s' "$info" | sed 's/[\\&/]/\\&/g')
 if grep -q '^manu_info' "$CONFIG"; then
-    sed -i "s/^manu_info.*/manu_info = \"$info\";/" "$CONFIG"
+    sed -i "s/^manu_info.*/manu_info = \"${escaped}\";/" "$CONFIG" ||
+        fail_request "500 Internal Server Error" "Save failed."
 else
-    echo "manu_info = \"$info\";" >> "$CONFIG"
+    printf 'manu_info = "%s";\n' "$info" >> "$CONFIG" ||
+        fail_request "500 Internal Server Error" "Save failed."
 fi
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D711_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D711_set.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
 
-echo "Content-Type: text/html"
-echo ""
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POSTDATA
 
@@ -24,13 +35,13 @@ if [ "$LEN" -gt 28 ]; then
     HEX=$(printf '%s' "$HEX" | cut -c1-28)
 else
     PAD=$(( (28 - LEN) / 2 ))
-    while [ $PAD -gt 0 ]; do
+    while [ "$PAD" -gt 0 ]; do
         HEX="${HEX}00"
         PAD=$((PAD - 1))
     done
 fi
 
-fw_setenv CA8271_VEN_NAME $HEX
+fw_setenv CA8271_VEN_NAME "$HEX" ||
+    fail_request "500 Internal Server Error" "Save failed."
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D712_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D712_set.sh
@@ -2,27 +2,48 @@
 
 CONFIG="/etc/onu_manu_modle.ini"
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POSTDATA
 
 urldecode() {
-  echo "$1" | sed 's/+/ /g; s/%3[Aa]/:/g; s/%2[Ff]/\//g'
+    printf '%b' "$(printf '%s' "$1" | sed 's/+/ /g; s/%/\\x/g')"
 }
 
 get_param() {
-  echo "$POSTDATA" | tr '&' '\n' | grep "^$1=" | cut -d= -f2
+    echo "$POSTDATA" | tr '&' '\n' | grep "^$1=" | cut -d= -f2-
 }
 
 model=$(urldecode "$(get_param model)")
 
+[ "${#model}" -le 32 ] ||
+    fail_request "400 Bad Request" "Invalid Model Number"
+printf '%s' "$model" | LC_ALL=C grep -Eq '^[[:print:]]*$' ||
+    fail_request "400 Bad Request" "Invalid Model Number"
+case "$model" in
+    *\"*) fail_request "400 Bad Request" "Invalid Model Number" ;;
+esac
 
+escaped=$(printf '%s' "$model" | sed 's/[\\&/]/\\&/g')
 if grep -q '^model' "$CONFIG"; then
-    sed -i "s/^model.*/model = \"$model\";/" "$CONFIG"
+    sed -i "s/^model.*/model = \"${escaped}\";/" "$CONFIG" ||
+        fail_request "500 Internal Server Error" "Save failed."
 else
-    echo "model = \"$model\";" >> "$CONFIG"
+    printf 'model = "%s";\n' "$model" >> "$CONFIG" ||
+        fail_request "500 Internal Server Error" "Save failed."
 fi
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D713_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_TLV_D713_set.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POSTDATA
 
@@ -23,13 +35,13 @@ if [ "$LEN" -gt 8 ]; then
     HEX=$(printf '%s' "$HEX" | cut -c1-8)
 else
     PAD=$(( (8 - LEN) / 2 ))
-    while [ $PAD -gt 0 ]; do
+    while [ "$PAD" -gt 0 ]; do
         HEX="${HEX}00"
         PAD=$((PAD - 1))
     done
 fi
 
-fw_setenv CA8271_HW_VER $HEX
+fw_setenv CA8271_HW_VER "$HEX" ||
+    fail_request "500 Internal Server Error" "Save failed."
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_ip_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_ip_set.sh
@@ -1,29 +1,36 @@
 #!/bin/sh
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POST_DATA
 
-IP=$(echo "$POST_DATA" | sed -n 's/.*IPAddr=\([^&]*\).*/\1/p')
+IP=$(echo "$POST_DATA" | sed -n 's/.*IPAddr=\([^&]*\).*/\1/p' | sed 's/+/ /g')
 
-IP=$(echo "$IP" | sed 's/+/ /g')
-IP=$(printf '%b' "${IP//%/\\x}")
-
-echo "$IP" | grep -Eq '^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[0-9]{1,2})\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[0-9]{1,2})$'
-if [ $? -ne 0 ]; then
-    echo "Invalid IP"
-    exit 1
-fi
+echo "$IP" | grep -Eq '^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[0-9]{1,2})\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[0-9]{1,2})$' ||
+    fail_request "400 Bad Request" "Invalid IP"
 
 FILE="/etc/network/interfaces"
 
-if grep -q "iface eth0" "$FILE"; then
-    sed -i "/iface eth0/,/iface / s/^\s*address .*/    address $IP/" "$FILE"
-else
-    echo "eth0 not found"
-    exit 1
-fi
+awk '
+    $1 == "iface" { in_eth0 = ($2 == "eth0") }
+    in_eth0 && $1 == "address" { found = 1 }
+    END { exit !found }
+' "$FILE" || fail_request "500 Internal Server Error" "eth0 address not found"
 
-echo "saved. IP updated to $IP, Please reboot."
+sed -i '/^iface eth0 /,/^iface / s/^[[:space:]]*address .*/    address '"$IP"'/' "$FILE" ||
+    fail_request "500 Internal Server Error" "Save failed."
 
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_password.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_password.sh
@@ -1,39 +1,51 @@
 #!/bin/sh
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
+
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
 
 read POST_DATA
 
-PASS1=$(echo "$POST_DATA" | sed -n 's/.*pass1=\([^&]*\).*/\1/p')
-PASS2=$(echo "$POST_DATA" | sed -n 's/.*pass2=\([^&]*\).*/\1/p')
-
-decode() {
-    local s="$1"
-    s=$(echo "$s" | sed 's/+/ /g')
-    printf '%b' "${s//%/\\x}"
+get_param() {
+    echo "$POST_DATA" | tr '&' '\n' | grep "^$1=" | cut -d= -f2-
 }
 
-PASS1=$(decode "$PASS1")
-PASS2=$(decode "$PASS2")
+decode() {
+    printf '%b' "$(printf '%s' "$1" | sed 's/+/ /g; s/%/\\x/g')"
+}
 
-if [ -z "$PASS1" ] || [ -z "$PASS2" ]; then
-    echo "Password empty"
-    exit 1
-fi
+PASS1=$(decode "$(get_param pass1)")
+PASS2=$(decode "$(get_param pass2)")
 
-if [ "$PASS1" != "$PASS2" ]; then
-    echo "Password mismatch"
-    exit 1
-fi
+[ -n "$PASS1" ] && [ "${#PASS1}" -le 32 ] ||
+    fail_request "400 Bad Request" "Invalid password"
+[ "$PASS1" = "$PASS2" ] ||
+    fail_request "400 Bad Request" "Password mismatch"
+printf '%s' "$PASS1" | LC_ALL=C grep -Eq '^[[:print:]]+$' ||
+    fail_request "400 Bad Request" "Invalid password"
 
-HASH=$(openssl passwd -crypt "$PASS1")
+HASH=$(openssl passwd -crypt "$PASS1") ||
+    fail_request "500 Internal Server Error" "Save failed."
 
 HTPASSWD="/script/web/www/.htpasswd"
+NEW_HTPASSWD="${HTPASSWD}.new.$$"
+trap 'rm -f "$NEW_HTPASSWD"' EXIT HUP INT TERM
 
-printf "admin:%s\n" "$HASH" > "$HTPASSWD"
+printf 'admin:%s\n' "$HASH" > "$NEW_HTPASSWD" &&
+    chmod 600 "$NEW_HTPASSWD" &&
+    mv "$NEW_HTPASSWD" "$HTPASSWD" ||
+    fail_request "500 Internal Server Error" "Save failed."
 
-chmod 600 "$HTPASSWD"
-
-echo "Password updated"
-
+trap - EXIT HUP INT TERM
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_ponmac_set.sh
+++ b/mod/siepon_a/SOURCE/script/web/www/cgi-bin/set_ponmac_set.sh
@@ -2,31 +2,34 @@
 
 CONFIG="/config/scfg.txt"
 
-echo "Content-Type: text/html"
-echo ""
+reply() {
+    if [ "$1" != "200 OK" ]; then
+        echo "Status: $1"
+    fi
+    echo "Content-Type: text/plain; charset=utf-8"
+    echo "Cache-Control: no-store"
+    echo ""
+    echo "$2"
+}
 
-# POST data get
+fail_request() {
+    reply "$1" "$2"
+    exit 1
+}
+
 read POSTDATA
 
-# MacAddr get
-MACADDR=$(echo "$POSTDATA" | sed -n 's/^MacAddr=\(.*\)$/\1/p')
+MACADDR=$(echo "$POSTDATA" | sed -n 's/^MacAddr=\(.*\)$/\1/p' | sed 's/%3[Aa]/:/g')
 
-# URL decode
-MACADDR=$(echo "$MACADDR" | sed 's/%3A/:/g')
+echo "$MACADDR" | grep -Eq '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' ||
+    fail_request "400 Bad Request" "Invalid MAC address"
 
-# MAC check
-echo "$MACADDR" | grep -Eq '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$'
-if [ $? -ne 0 ]; then
-    echo "Invalid MAC address"
-    exit 1
-fi
-
-# write
 if grep -q '^MAC CFG_ID_MAC_ADDRESS' "$CONFIG"; then
-    sed -i "s/^MAC CFG_ID_MAC_ADDRESS.*/MAC CFG_ID_MAC_ADDRESS = $MACADDR;/" "$CONFIG"
+    sed -i "s/^MAC CFG_ID_MAC_ADDRESS.*/MAC CFG_ID_MAC_ADDRESS = $MACADDR;/" "$CONFIG" ||
+        fail_request "500 Internal Server Error" "Save failed."
 else
-    echo "MAC CFG_ID_MAC_ADDRESS = $MACADDR;" >> "$CONFIG"
+    printf 'MAC CFG_ID_MAC_ADDRESS = %s;\n' "$MACADDR" >> "$CONFIG" ||
+        fail_request "500 Internal Server Error" "Save failed."
 fi
 
-echo "Saved"
-
+reply "200 OK" "Saved"

--- a/mod/siepon_a/SOURCE/script/web/www/password.html
+++ b/mod/siepon_a/SOURCE/script/web/www/password.html
@@ -13,9 +13,7 @@
   <input type="submit" value="Save">
 </form>
 
-<script>
-</script>
+<script src="save.js"></script>
 
 </body>
 </html>
-

--- a/mod/siepon_a/SOURCE/script/web/www/save.js
+++ b/mod/siepon_a/SOURCE/script/web/www/save.js
@@ -1,0 +1,122 @@
+(function () {
+  "use strict";
+
+  function encode(value) {
+    return encodeURIComponent(value).replace(/%20/g, "+");
+  }
+
+  function encodeForm(form) {
+    var fields = form.elements;
+    var values = [];
+    var i;
+
+    for (i = 0; i < fields.length; i += 1) {
+      var field = fields[i];
+      var type = (field.type || "").toLowerCase();
+
+      if (!field.name || field.disabled || type === "submit" ||
+          type === "button" || type === "reset" || type === "file") {
+        continue;
+      }
+
+      if ((type === "checkbox" || type === "radio") && !field.checked) {
+        continue;
+      }
+
+      values.push(encode(field.name) + "=" + encode(field.value));
+    }
+
+    return values.join("&");
+  }
+
+  function initializeSaveForm() {
+    var form = document.querySelector('form[method="POST"]');
+
+    if (!form || !window.fetch) {
+      return;
+    }
+
+    var submit = form.querySelector('input[type="submit"]');
+    var status = document.createElement("span");
+    var saving = false;
+
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    status.style.marginLeft = "0.75em";
+
+    if (submit && submit.parentNode) {
+      submit.parentNode.insertBefore(status, submit.nextSibling);
+    } else {
+      form.appendChild(status);
+    }
+
+    function setFinished(message, color) {
+      saving = false;
+      if (submit) {
+        submit.disabled = false;
+      }
+      status.style.color = color;
+      status.textContent = message;
+    }
+
+    function warnBeforeUnload(event) {
+      if (!saving) {
+        return undefined;
+      }
+
+      event.preventDefault();
+      event.returnValue = "";
+      return "";
+    }
+
+    window.addEventListener("beforeunload", warnBeforeUnload);
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+
+      if (saving) {
+        return;
+      }
+
+      saving = true;
+      if (submit) {
+        submit.disabled = true;
+      }
+      status.style.color = "";
+      status.textContent = "Saving... Please wait.";
+
+      fetch(form.action, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body: encodeForm(form),
+        cache: "no-store",
+        credentials: "same-origin"
+      })
+        .then(function (response) {
+          return response.text().then(function (message) {
+            return {
+              ok: response.ok,
+              message: message.trim()
+            };
+          });
+        })
+        .then(function (result) {
+          if (!result.ok || result.message !== "Saved") {
+            throw new Error(result.message || "Save failed.");
+          }
+          setFinished("Saved", "green");
+        })
+        .catch(function (error) {
+          setFinished(error.message || "Save failed.", "darkred");
+        });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeSaveForm);
+  } else {
+    initializeSaveForm();
+  }
+}());

--- a/mod/siepon_a/SOURCE/script/web/www/systemIP.html
+++ b/mod/siepon_a/SOURCE/script/web/www/systemIP.html
@@ -3,7 +3,7 @@
 
 <h2>System IP</h2>
 <hr>
-<p>Configure the ONU management IP address.</p>
+<p>Configure the ONU management IP address. The new address takes effect after reboot.</p>
 
 <form method="POST" action="cgi-bin/set_ip_set.sh">
   ONU Managemnt IP (Exanple : 192.168.0.1)<br>
@@ -20,7 +20,7 @@ fetch("cgi-bin/set_ip_get.sh")
   })
   .catch(err => console.error(err));
   </script>
+<script src="save.js"></script>
 
 </body>
 </html>
-


### PR DESCRIPTION
## Summary

**Bug fix / Quality of life**

On an actual CIG XE-99S, we reproduced multiple times that pressing Save could
replace the settings page with a blank content frame for a long time. Leaving
before `Saved` appeared could result in the submitted setting not being saved.

This change updates the current SIEPON-A source directly. It keeps the settings
page visible, reports the actual CGI result, and reduces unnecessary U-Boot
environment writes.

## Changes

- Add one shared in-page save handler to all 13 menu-linked setting pages,
  including Reboot Block.
- Show `Saving... Please wait.`, prevent duplicate submissions, and protect
  navigation while a save is in progress.
- Show `Saved` only after the CGI returns a successful response.
- Return a clear failure response for invalid input or a failed environment/file
  write.
- Batch each multi-key environment update into one native `fw_setenv -s -`
  operation.

| Setting | Environment writes before | After |
| --- | ---: | ---: |
| Force Bridge | 2 | 1 |
| Firmware Info (D7/03) | 4 | 1 |
| Chipset Info (D7/04) | 2 | 1 |
| Date of Manufacture (D7/05) | 2 | 1 |

Single-key settings remain one write. No post-write readback, retry, rollback,
or periodic reconciliation is added.

The file-backed PON MAC, D7/06, D7/12, System IP, and Login Password handlers
now also propagate their write result. Password replacement uses a temporary
file and rename so a failed write does not truncate the active password file.

## Scope

The change is limited to the SIEPON-A Web settings source under
`mod/siepon_a/SOURCE/script/web/www`.

It does not change getters, the Status page, the Reboot action, the unlinked
legacy Traffic Control page, Force Bridge forwarding, OAM behavior, OLT
interaction, ISP DHCP passthrough, or VLAN/PPPoE handling.

## Validation

- `/bin/sh -n` passed on all 13 modified CGI setters.
- `node --check` passed on the shared save helper.
- Pinned-Docker fixtures passed for all 13 setting paths.
- The fixtures cover persisted output, multi-key batch counts, invalid input,
  representative write failures, and absence of post-write environment reads.
- In an actual-device browser test of the same shared save flow and Force Bridge
  handler, the page remained visible, reported `Saved`, and persisted the
  submitted multi-key setting.
