### PR TITLE
RFC: avoid duplicate SDK loading in periodic SIEPON-A Force Bridge replay

### DIFF
--- a/mod/siepon_a/patches/conditional-sdk-load/README.md
+++ b/mod/siepon_a/patches/conditional-sdk-load/README.md
@@ -1,0 +1,41 @@
+# RFC: avoid duplicate SDK loading in periodic SIEPON-A Force Bridge replay
+
+Severity: **Low** — recurring overhead is proven statically, but no failure or
+measurable runtime impact has been attributed to it.
+
+## Summary
+
+With Force Bridge enabled, `Background_API.sh` starts a new `iros` process
+every 30 seconds and reissues 32 classifier rules. `/etc/ca-iros.rc` already
+loads `SC_COMMAND_LIB.tcl`, but `Background_API.tcl` loads the same 657,238-byte
+SDK library again.
+
+This patch skips the second SDK evaluation when the two required WCA commands
+are already available. If either command is missing, the existing full-library
+load remains the fallback.
+
+Static review found no top-level hardware operation in the SDK Tcl file; it
+initializes Tcl variables and defines procedures. The second evaluation
+therefore appears redundant in the shipped path.
+
+The replay interval, classifier rules, LLID ranges, Force Traffic behavior, and
+OAM library are unchanged. Please review whether this small recurring cleanup
+is worth adopting.
+
+## Follow-up question
+
+Does the firmware or SDK provide a reliable notification after OLT/DPoE
+classifier provisioning completes?
+
+If so, could the current 30-second replay be replaced by reapplying the Force
+Bridge rules only when that notification occurs? If the notification cannot
+cover every rule update, the current periodic reconciliation should remain
+unchanged.
+
+This PR does not change the rule-replay mechanism.
+
+## Validation
+
+- Tcl 8.5 tests passed for preloaded, standalone, and partial-load paths.
+- Hardware-facing Tcl procedure bodies are unchanged.
+- No firmware image has been built or tested on hardware.

--- a/mod/siepon_a/patches/conditional-sdk-load/rootfs/script/tcl/Background_API.tcl
+++ b/mod/siepon_a/patches/conditional-sdk-load/rootfs/script/tcl/Background_API.tcl
@@ -1,0 +1,86 @@
+# ca-iros normally loads these commands through /etc/ca-iros.rc. Keep this
+# script usable in other interpreters without loading the SDK twice.
+if {[namespace which -command ::gw::wca_classifier_rule_add] eq "" ||
+    [namespace which -command ::gw::wca_epon_llid_traffic_enable_set] eq ""} {
+    source /etc/cortina/iros/qa/wca/SC_COMMAND_LIB.tcl
+}
+if {[namespace which -command ::wca_classifier_rule_add] eq "" ||
+    [namespace which -command ::wca_epon_llid_traffic_enable_set] eq ""} {
+    namespace import -force ::gw::*
+}
+
+proc network_pon_classifier_force_bridge_up {} {
+    #LAN->PON
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x0007
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x090f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x1217
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x1b1f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x2427
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x2d2f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x3637
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x3f3f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x4047
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x494f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x5257
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x5b5f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x6467
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x6d6f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x7677
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x30006 -action_forward 3 -action_dest_port 0x20007 -action_option_flow_id 0x7f7f
+}
+
+proc network_pon_classifier_force_bridge_down {} {
+    #PON->LAN
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x0007
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x090f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x1217
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x1b1f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x2427
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x2d2f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x3637
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x3f3f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x4047
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x494f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x5257
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x5b5f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x6467
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x6d6f
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x7677
+    wca_classifier_rule_add -device_id 0 -priority 7 -src_port 0x20007 -action_forward 3 -action_dest_port 0x30006 -llid_cos_index 0x7f7f
+}
+
+proc network_pon_mpcp_force_traffic_enable {} {
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x00 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x01 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x02 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x03 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x04 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x05 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x06 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x07 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x08 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x09 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x0a -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x0b -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x0c -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x0d -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x0e -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x0f -upstream 1 -downstream 1
+
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x10 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x11 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x12 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x13 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x14 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x15 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x16 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x17 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x18 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x19 -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x1a -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x1b -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x1c -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x1d -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x1e -upstream 1 -downstream 1
+    wca_epon_llid_traffic_enable_set -device_id 0 -port_id 0x20007 -llid 0x1f -upstream 1 -downstream 1
+}


### PR DESCRIPTION
## Summary

Severity: **Low** — recurring overhead is proven statically, but no failure or
measurable runtime impact has been attributed to it.

With Force Bridge enabled, `Background_API.sh` starts a new `iros` process
every 30 seconds and reissues 32 classifier rules. `/etc/ca-iros.rc` already
loads `SC_COMMAND_LIB.tcl`, but `Background_API.tcl` loads the same 657,238-byte
SDK library again.

This patch skips the second SDK evaluation when the two required WCA commands
are already available. If either command is missing, the existing full-library
load remains the fallback.

Static review found no top-level hardware operation in the SDK Tcl file; it
initializes Tcl variables and defines procedures. The second evaluation
therefore appears redundant in the shipped path.

The replay interval, classifier rules, LLID ranges, Force Traffic behavior, and
OAM library are unchanged. Please review whether this small recurring cleanup
is worth adopting.

## Follow-up question

Does the firmware or SDK provide a reliable notification after OLT/DPoE
classifier provisioning completes?

If so, could the current 30-second replay be replaced by reapplying the Force
Bridge rules only when that notification occurs? If the notification cannot
cover every rule update, the current periodic reconciliation should remain
unchanged.

This PR does not change the rule-replay mechanism.

## Validation

- Tcl 8.5 tests passed for preloaded, standalone, and partial-load paths.
- Hardware-facing Tcl procedure bodies are unchanged.
- No firmware image has been built or tested on hardware.
